### PR TITLE
Fix frontend failed test cases for login, categories and search

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,5 +28,8 @@ jobs:
           cd client
           npm install
 
-      - name: Run Jest tests
+      - name: Run Jest tests frontend
         run: npm run test:frontend
+
+      - name: Run Jest tests backend
+        run: npm run test:backend

--- a/client/src/pages/Categories.js
+++ b/client/src/pages/Categories.js
@@ -8,7 +8,7 @@ const Categories = () => {
     <Layout title={"All Categories"}>
       <div className="container">
         <div className="row">
-          {categories.map((c) => (
+          {categories && categories.map((c) => (
             <div className="col-md-6 mt-5 mb-3 gx-3 gy-3" key={c._id}>
               <Link to={`/category/${c.slug}`} className="btn btn-primary">
                 {c.name}

--- a/client/src/pages/Search.js
+++ b/client/src/pages/Search.js
@@ -9,12 +9,12 @@ const Search = () => {
         <div className="text-center">
           <h1>Search Resuts</h1>
           <h6>
-            {values?.results.length < 1
+            {!values?.results || values?.results.length < 1
               ? "No Products Found"
               : `Found ${values?.results.length}`}
           </h6>
           <div className="d-flex flex-wrap mt-4">
-            {values?.results.map((p) => (
+            {values?.results && values?.results.map((p) => (
               <div className="card m-2" style={{ width: "18rem" }}>
                 <img
                   src={`/api/v1/product/product-photo/${p._id}`}


### PR DESCRIPTION
This pull request improves the reliability of frontend and backend tests, enhances the robustness of category and search rendering, and makes the login component tests more precise and isolated. The main changes are grouped below by theme.

**Testing Improvements**

* The GitHub Actions workflow now separates frontend and backend Jest test runs for better clarity and isolation.
* The login component tests (`Login.test.js`) now clear all mocks before each test and re-mock API responses to ensure tests are isolated and not affected by previous runs. Additionally, API call assertions now verify the exact parameters sent, and notification checks are more precise. 

**Frontend Robustness**

* The `Categories` page now safely checks for the existence of `categories` before mapping, preventing runtime errors if the data is missing or undefined.
* The `Search` page now verifies that `values.results` exists before rendering search results, ensuring no errors occur when there are no results.